### PR TITLE
 - added server/ folder for server-side code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/server/node_modules
 /.pnp
 .pnp.js
 

--- a/package.json
+++ b/package.json
@@ -7,14 +7,10 @@
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.6.2",
     "@types/crypto-js": "^3.1.43",
-    "aws-sdk": "^2.864.0",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "crypto-js": "^3.3.0",
-    "dotenv": "^8.2.0",
-    "express": "^4.17.1",
-    "express-fileupload": "^1.2.1",
     "fs": "0.0.1-security",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -35,7 +31,9 @@
     "typescript": "^3.9.9"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start-react": "react-scripts start",
+    "start": "cd server && node server.js",
+    "install-all": "npm install && cd server && npm install",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "heo-server",
+  "version": "1.0.0",
+  "description": "node js server for heo-web application",
+  "main": "server.js",
+  "scripts": {
+    "test": "test"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "aws-sdk": "^2.864.0",
+    "dotenv": "^8.2.0",
+    "express": "^4.17.1",
+    "express-fileupload": "^1.2.1"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const path = require('path');
+const AWS = require('aws-sdk');
+const fileUpload = require('express-fileupload');
+const app = express();
+
+// Serve the static files from the React app
+app.use(express.static(path.join(__dirname, '../build')));
+
+//TODO: An api endpoint that will handle image uploads
+app.post('/api/uploadimage', (req,res) => {
+    console.log('Upload image to AWS here');
+});
+
+//TODO: An api endpoint that will handle metadata uploads
+app.post('/api/uploadmeta', (req,res) => {
+    console.log('construct a JSON metadata file and upload it to AWS here');
+});
+
+// Handles any requests that don't match the ones above.
+// All other routing except paths defined above is done by React in the UI
+app.get('*', (req,res) =>{
+    res.sendFile(path.join(__dirname, '..', 'build', 'index.html'));
+});
+
+const port = process.env.PORT || 5000;
+app.listen(port);
+
+console.log('App is listening on port ' + port);


### PR DESCRIPTION
 - added simple ExpressJS server in server/server.js
 - added placeholder routes to server/server.js for server APIs
 - routing that is not handled by JS is handled by ReactJS
 - server/server.js relies on React build to have placed React files
   in /build/, which is what React build normally does
 - top level package.json now has "install-all" and "start-reat" scripts.
   "npm install-all" runs "npm install" in top level folder for React UI
   and in /server/ folder for the server side.
 - "npm start" now uses /server/server.js and /server/node_modules for NodeJS server